### PR TITLE
fix: Background solid color to avoid border lines to cross the PR list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,10 @@
 name: tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/assets/stylesheets/redmine_merge_request_links.css
+++ b/assets/stylesheets/redmine_merge_request_links.css
@@ -3,6 +3,7 @@ div#issue-changesets {
 }
 
 div#issue-merge-requests {
+  background-color: inherit;
   float: right;
   width: 45%;
   margin: 1em 0 2em 1em;

--- a/init.rb
+++ b/init.rb
@@ -1,10 +1,8 @@
-require 'redmine'
-
 Redmine::Plugin.register :redmine_merge_request_links do
   name 'Redmine Merge Request Links'
-  author 'Tim Fischbach'
-  description 'Display links to Gitlab merge requests and GitHub pull requests'
-  version '2.2.0'
+  author 'Tim Fischbach (orig)'
+  description 'Display links to Gitlab merge requests and Gitea/GitHub pull requests'
+  version '2.2.1'
   url 'https://github.com/tf/redmine_merge_request_links'
   author_url 'https://github.com/tf'
 


### PR DESCRIPTION
- reduce the amount of checks permformed.
- Set the inherited background color as (solid in the case of redmine) in order to avoid the change history border lines to cross the pull request listing box.